### PR TITLE
switch benchmarks to point to prototype-maps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,14 +52,27 @@ jobs:
       - name: Run test benchmarks
         if: github.event_name != 'workflow_dispatch'
         run: |
-          python main.py --runs 10
+          python main.py \
+            --detect-provider \
+            --approach direct-client \
+            --zarr-v2-dataset c2
+
+          python main.py \
+            --approach direct-client \
+            --zarr-v3-dataset c2 \
+            --action zoom_in \
+            --zoom-level 1
 
       - name: Run benchmarks using user inputs
         if: github.event_name == 'workflow_dispatch'
         run: |
           python main.py \
                 --runs ${{ github.event.inputs.runs }} \
-                --detect-provider
+                --detect-provider \
+                --approach direct-client \
+                --zarr-v3-dataset c2 \
+                --action zoom_in \
+                --zoom-level 1
 
       - name: Create Pull Request
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.upload-results == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,11 @@ jobs:
           python main.py \
             --detect-provider \
             --approach direct-client \
-            --zarr-v2-dataset c2
+            --zarr-v2-dataset 5MB-chunks
 
           python main.py \
             --approach direct-client \
-            --zarr-v3-dataset c2 \
+            --zarr-v3-dataset 10MB-chunks \
             --action zoom_in \
             --zoom-level 1
 
@@ -70,7 +70,7 @@ jobs:
                 --runs ${{ github.event.inputs.runs }} \
                 --detect-provider \
                 --approach direct-client \
-                --zarr-v3-dataset c2 \
+                --zarr-v3-dataset 10MB-chunks \
                 --action zoom_in \
                 --zoom-level 1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,11 +55,13 @@ jobs:
           python main.py \
             --detect-provider \
             --approach direct-client \
-            --zarr-v2-dataset 5MB-chunks
+            --dataset 5MB-chunks \
+            --zarr-version v2
 
           python main.py \
             --approach direct-client \
-            --zarr-v3-dataset 10MB-chunks \
+            --dataset 10MB-chunks \
+            --zarr-version v3 \
             --action zoom_in \
             --zoom-level 1
 
@@ -70,7 +72,8 @@ jobs:
                 --runs ${{ github.event.inputs.runs }} \
                 --detect-provider \
                 --approach direct-client \
-                --zarr-v3-dataset 10MB-chunks \
+                --dataset 10MB-chunks \
+                --zarr-version v3 \
                 --action zoom_in \
                 --zoom-level 1
 

--- a/main.py
+++ b/main.py
@@ -10,7 +10,8 @@ from playwright.async_api import async_playwright
 from rich import print
 
 BASE_URL = 'https://prototype-maps.vercel.app'
-DATASETS = {'direct-client': {'v2': ['c2', 'c3', 'c4', 'c5'], 'v3': ['c2', 'c3', 'c4', 'c5']}}
+DATASETS_KEYS = ['1MB-chunks', '5MB-chunks', '10MB-chunks', '25MB-chunks']
+DATASETS = {'direct-client': {'v2': DATASETS_KEYS, 'v3': DATASETS_KEYS}}
 ZARR_VERSIONS = list(DATASETS['direct-client'].keys())
 ZARR_V2_DATASETS = DATASETS['direct-client']['v2']
 ZARR_V3_DATASETS = DATASETS['direct-client']['v3']


### PR DESCRIPTION
this pull request updates the benchmark to use the prototype maps. the command line interface is still a work in progress though. here's what the current interface includes:

```bash
$ python main.py --help
usage: main.py [-h] [--runs RUNS] [--detect-provider] [--approach APPROACH] [--zarr-v2-dataset ZARR_V2_DATASET]
               [--zarr-v3-dataset ZARR_V3_DATASET] [--non-headless] [--s3-bucket S3_BUCKET] [--action ACTION]
               [--zoom-level ZOOM_LEVEL]

options:
  -h, --help            show this help message and exit
  --runs RUNS           Number of runs to perform
  --detect-provider     Detect provider
  --approach APPROACH   Approach to use. Must be one of: ['direct-client']
  --zarr-v2-dataset ZARR_V2_DATASET
                        Zarr v2 dataset name. Must be one of: ['c2', 'c3', 'c4', 'c5']
  --zarr-v3-dataset ZARR_V3_DATASET
                        Zarr v3 dataset name. Must be one of: ['c2', 'c3', 'c4', 'c5']
  --non-headless        Run in non-headless mode
  --s3-bucket S3_BUCKET
                        S3 bucket name
  --action ACTION       Action to perform. Must be one of: ['zoom_in', 'zoom_out']
  --zoom-level ZOOM_LEVEL
                        Zoom level
```

To use it, the user needs to specify the approach and dataset as follows:

```bash
python main.py --approach direct-client --zarr-v2-dataset c2 --action zoom_in --zoom-level 1
```

@katamartin / @maxrjones, i would love to hear your take on this

